### PR TITLE
Bump composer plugin api to semantic version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "composer-plugin-api": "1.0.0",
+        "composer-plugin-api": "^1.0",
         "fduch/netrc": "<2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Currently composer-plugin-api version hardcoded as 1.0.0 that can be harmful when composer team release new versions of composer api
